### PR TITLE
Remove conda-forge from channels

### DIFF
--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -1,7 +1,6 @@
 name: nextstrain
 channels:
 - bioconda
-- conda-forge
 - defaults
 dependencies:
 - cvxopt


### PR DESCRIPTION
Mirror @trvrb's change in augur [1] by removing an unnecessary channel.

[1] https://github.com/nextstrain/augur/pull/411