### PR TITLE
Add dependency for forecasts

### DIFF
--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -7,6 +7,7 @@ dependencies:
 - fasttree
 - iqtree
 - mafft
+- opencv
 - pandas
 - python=3.6*
 - nodejs=10


### PR DESCRIPTION
Forecasts use OpenCV's implementation of earth mover's distance. Since forecasts
are part of seasonal-flu builds, this dependency should be reflected in the base
"nextstrain" environment. Alternately, we need to figure out a better way to
support different environments per build.