### PR TITLE
Install dependencies from conda that otherwise are built from source

### DIFF
--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -4,11 +4,13 @@ channels:
 - defaults
 dependencies:
 - cvxopt
+- datrie
 - fasttree
 - iqtree
 - mafft
 - opencv
 - pandas
+- psutil
 - python=3.6*
 - nodejs=10
 - raxml
@@ -18,3 +20,4 @@ dependencies:
 - pip:
   - nextstrain-augur
   - nextstrain-cli
+  - rethinkdb==2.3.0.post6


### PR DESCRIPTION
Both datrie and psutil are required by a Nextstrain pip dependency and have to
be built from source on install. This causes environment creation to fail for
users who do not have gcc installed. This commit installs those dependencies
from conda as prebuilt binaries allowing pip to skip installation from source.

This commit also adds a dependency for most Bedford lab pipelines, the rethinkdb
module used to access the sequence database.