### PR TITLE
Don't hardcode the Conda install path when fixing permissions on macOS

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Fix Conda permissions on macOS
-        run: sudo chown -R $UID $HOME/.conda
+        run: sudo chown -R $UID $CONDA
         if: matrix.os == 'macos-latest'
 
       - name: Install Nextstrain environment


### PR DESCRIPTION
It appears that GitHub recently (between 10 March and 24 March) moved
the Conda install from ~/.conda to /usr/local/miniconda, which caused
the permission errors to be reintroduced and our workflow to fail.

Resolves #5.

### Testing
https://github.com/nextstrain/conda/actions/runs/72825993 passed.