### PR TITLE
Install AWS CLI via pip

### DIFF
--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -18,6 +18,7 @@ dependencies:
 - git
 - pip
 - pip:
+  - awscli
   - nextstrain-augur
   - nextstrain-cli
   - rethinkdb==2.3.0.post6


### PR DESCRIPTION
At least one critical Nextstrain build ([ncov](https://github.com/nextstrain/ncov/blob/1cbf8a9caabb0a6b0e941fab7c9dedf3fe845cff/Snakefile#L79-L80)) requires AWS CLI to run, but this
dependency is only available through [the Docker image](https://github.com/nextstrain/docker-base/blob/022363cf6186bdf90a2ad360f514732dd01e1af8/Dockerfile#L109) or when users manually
install these tools. This commit should make the AWS tools available to all
users working with Nextstrain with no effort on their part.

Note, this commit installs awscli from PyPI instead of a conda channel. Support
for conda packages of awscli seems to be inconsistent, so this approach is more
likely to work in the future.