### PR TITLE
Add Snakemake as a dependency for the Nextstrain environment

### DIFF
--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -22,3 +22,4 @@ dependencies:
   - nextstrain-augur
   - nextstrain-cli
   - rethinkdb==2.3.0.post6
+  - snakemake


### PR DESCRIPTION
Maintains presence of snakemake executable in the Nextstrain environment in
preparation for removing Snakemake as an augur dependency [1]. Two important
points to note about this change are:

  1. We install Snakemake from PyPI instead of conda to ensure we have the
  latest version and to minimize conda environment conflicts that have been
  issues for many users in the past.

  2. We do not pin Snakemake to a specific earlier version here as we did in
  augur (v5.10.0). This means the latest version of Snakemake will be installed
  by default with whatever breaking changes might occur in Snakemake's own
  API. This allows us to take advantage of the the latest features and bug fixes
  for Snakemake, but it also creates a breaking change for augur that will be
  reflected in a major version release of augur.

[1] https://github.com/nextstrain/augur/pull/557