### PR TITLE
Pin Snakemake version

### DIFF
--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -22,4 +22,4 @@ dependencies:
   - nextstrain-augur
   - nextstrain-cli
   - rethinkdb==2.3.0.post6
-  - snakemake
+  - snakemake==5.26.1


### PR DESCRIPTION
Snakemake versions 5.27.* recently changed the minimum Python version supported to 3.7, changed it back to 3.5, and ended up breaking DAG construction for Python <3.7. Although there is [an open PR to resolve this issue](https://github.com/snakemake/snakemake/pull/726), our Nextstrain pipelines are currently broken and need to be fixed. This commit pins the latest working version of Snakemake until the issue described above gets resolved.

Resolves #9 and [a related issue reported on the discussion forum](https://discussion.nextstrain.org/t/attributeerror-module-asyncio-has-no-attribute-create-task/187).