### PR TITLE
Simplify dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,19 @@
 
 The `nextstrain.yml` file in this repo is hosted at <http://data.nextstrain.org/nextstrain.yml> and serves as an environment definition for Conda.
 
-We strongly recommend [Mamba](https://github.com/mamba-org/mamba) as a faster, drop-in replacement for the default Conda installer.
+Setup the Nextstrain environment by running:
 
+    curl http://data.nextstrain.org/nextstrain.yml -o nextstrain.yml
+    conda env create -f nextstrain.yml
+    conda activate nextstrain
+    npm install --global auspice
+
+For a faster installation process, use [Mamba](https://github.com/mamba-org/mamba) as a drop-in replacement for Conda's installer.
+
+    # Install Mamba
     conda install -c conda-forge mamba
 
-After installing Mamba, setup the Nextstrain environment by running:
-
+    # Create environment with Mamba.
     curl http://data.nextstrain.org/nextstrain.yml -o nextstrain.yml
     mamba env create -f nextstrain.yml
     conda activate nextstrain

--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@
 
 The `nextstrain.yml` file in this repo is hosted at <http://data.nextstrain.org/nextstrain.yml> and serves as an environment definition for Conda.
 
-You can set it up by running:
+We strongly recommend [Mamba](https://github.com/mamba-org/mamba) as a faster, drop-in replacement for the default Conda installer.
+
+    conda install -c conda-forge mamba
+
+After installing Mamba, setup the Nextstrain environment by running:
 
     curl http://data.nextstrain.org/nextstrain.yml -o nextstrain.yml
-    conda env create -f nextstrain.yml
+    mamba env create -f nextstrain.yml
     conda activate nextstrain
     npm install --global auspice
 

--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -6,11 +6,11 @@ channels:
 dependencies:
 - augur
 - nextalign=0.1.6
+- nextstrain-cli
 - python>=3.6*
 - nodejs>=10
 - git
 - pip
 - pip:
   - awscli
-  - nextstrain-cli
   - rethinkdb==2.3.0.post6

--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - augur
 - python>=3.6*
-- nodejs=10
+- nodejs>=10
 - git
 - pip
 - pip:

--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -5,6 +5,7 @@ channels:
 - defaults
 dependencies:
 - augur
+- nextalign=0.1.6
 - python>=3.6*
 - nodejs>=10
 - git

--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -1,25 +1,15 @@
 name: nextstrain
 channels:
+- conda-forge
 - bioconda
 - defaults
 dependencies:
-- cvxopt
-- datrie
-- fasttree
-- iqtree
-- mafft
-- opencv
-- pandas
-- psutil
-- python=3.6*
+- augur
+- python>=3.6*
 - nodejs=10
-- raxml
-- vcftools
 - git
 - pip
 - pip:
   - awscli
-  - nextstrain-augur
   - nextstrain-cli
   - rethinkdb==2.3.0.post6
-  - snakemake==5.26.1


### PR DESCRIPTION
Install Augur from [its Bioconda package](https://bioconda.github.io/recipes/augur/README.html) which defines most dependencies required for the Nextstrain environment. This change allows us to remove most dependencies from the Nextstrain environment file and avoid mismatches in dependency versions across environments.

Similarly, this PR also allows Python >=3.6 to be installed instead of pinning to 3.6 specifically. This change should help us avoid breaking environments when dependencies no longer support 3.6 (for example, [when pandas no longer support Python 3.6](https://github.com/nextstrain/ncov/issues/539)).

This PR removes opencv since it is no longer required by any of our workflows and adds substantial complexity to the Nextstrain environment.

Finally, this PR updates the README instructions to recommend Mamba as an alternative to the default conda installer. Other references to our conda environment file should follow the same pattern, so users get the fastest and most accurate environments possible.

Fixes https://github.com/nextstrain/ncov/issues/539
