### PR TITLE
Increase minimal augur version to 11.3.0

### DIFF
--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -4,7 +4,7 @@ channels:
 - bioconda
 - defaults
 dependencies:
-- augur
+- augur>=11.3.0
 - nextalign=0.1.6
 - nextstrain-cli
 - python>=3.6*


### PR DESCRIPTION
ncov v3 and greater require `augur.io` for `combine-and-dedup-fastas.py` and `sanitize_sequences.py` which is only present in augur releases from 11.3.0

### Description of proposed changes    
Forces conda envs created from the yaml to install augur >= version 11.3.0 

### Related issue(s)  
Didn't create a new issue but `ncov` v5 was failing when executing the above scripts as `io` couldn't be imported from the earlier augur install (why conda chose to install 11.1.0 when creating a new clean environment is another question...).  Figured it was quicker to just make a PR with the fix than also create an issue.

### Testing
Created environment with `conda env create -f nextstrain.yaml` and successfully ran the `ncov` example data run with the latest `ncov` commit (v5 + ceb3a1a).