### PR TITLE
update(nextstrain.yml): bump Augur to v13, nextalign to v1

### DIFF
--- a/nextstrain.yml
+++ b/nextstrain.yml
@@ -4,10 +4,10 @@ channels:
 - bioconda
 - defaults
 dependencies:
-- augur>=11.3.0
-- nextalign=0.1.6
+- augur>=13
+- nextalign=1
 - nextstrain-cli
-- python>=3.6*
+- python>=3.6
 - nodejs>=10
 - git
 - pip


### PR DESCRIPTION
Wildcards are deprecated in conda yaml env files, see: https://github.com/conda/conda/issues/9140

I'm confused why we have so many different nextstrain.yml flying around in different repos. This could cause confusion among users. Googling `nextstrain env yml conda` yields this one for example, even though the repo is hardly used.